### PR TITLE
Fix some build errors & warnings in kin_2023_may_11

### DIFF
--- a/runtime/src/accounts.rs
+++ b/runtime/src/accounts.rs
@@ -1624,6 +1624,7 @@ mod tests {
             None,
             &HashMap::new(),
             &LoadedProgramsForTxBatch::default(),
+            true,  // set_exempt_rent_epoch_max
         )
     }
 
@@ -3428,6 +3429,7 @@ mod tests {
             account_overrides,
             &HashMap::new(),
             &LoadedProgramsForTxBatch::default(),
+            true,  // set_exempt_rent_epoch_max
         )
     }
 

--- a/runtime/src/accounts_db.rs
+++ b/runtime/src/accounts_db.rs
@@ -7279,7 +7279,7 @@ impl AccountsDb {
                         assert!(!file_name.is_empty());
                         (!r.is_empty() && r.iter().any(|b| !b.is_empty())).then(|| {
                             // error if we can't write this
-                            cache_hash_data.save(&file_name, r).unwrap();
+                            cache_hash_data.save(&file_name, &r).unwrap();
                             cache_hash_data.load_map(&file_name).unwrap()
                         })
                     })

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -7042,7 +7042,7 @@ impl Bank {
         });
 
         let (verified_accounts, verify_accounts_time_us) = measure_us!({
-            let should_verify_accounts = false;//!self.rc.accounts.accounts_db.skip_initial_hash_calc;
+            let should_verify_accounts = false; // !self.rc.accounts.accounts_db.skip_initial_hash_calc;
             if should_verify_accounts {
                 info!("Verifying accounts...");
                 let verified = self.verify_accounts_hash(

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -11335,6 +11335,7 @@ fn test_rent_state_list_len() {
         None,
         &HashMap::new(),
         &LoadedProgramsForTxBatch::default(),
+        true,
     );
 
     let compute_budget = bank.runtime_config.compute_budget.unwrap_or_else(|| {

--- a/runtime/src/cache_hash_data.rs
+++ b/runtime/src/cache_hash_data.rs
@@ -285,10 +285,10 @@ impl CacheHashData {
     pub fn save(
         &self,
         file_name: impl AsRef<Path>,
-        data: Vec<Vec<EntryType>>,
+        data: &Vec<Vec<EntryType>>,
     ) -> Result<(), std::io::Error> {
         let mut stats = CacheHashDataStats::default();
-        let result = self.save_internal(file_name, data, &mut stats);
+        let result = self.save_internal(file_name, &data, &mut stats);
         self.stats.lock().unwrap().accumulate(&stats);
         result
     }
@@ -296,7 +296,7 @@ impl CacheHashData {
     fn save_internal(
         &self,
         file_name: impl AsRef<Path>,
-        data: Vec<Vec<EntryType>>,
+        data: &Vec<Vec<EntryType>>,
         stats: &mut CacheHashDataStats,
     ) -> Result<(), std::io::Error> {
         let mut m = Measure::start("save");
@@ -333,7 +333,7 @@ impl CacheHashData {
             x.into_iter().for_each(|item| {
                 let d = cache_file.get_mut(i as u64);
                 i += 1;
-                *d = item;
+                *d = *item;
             })
         });
         assert_eq!(i, entries);

--- a/runtime/src/snapshot_utils.rs
+++ b/runtime/src/snapshot_utils.rs
@@ -1814,11 +1814,11 @@ pub fn bank_from_latest_snapshot_dir(
 /// and hash
 fn verify_bank_against_expected_slot_hash(
     bank: &Bank,
-    expected_slot: Slot,
-    expected_hash: SnapshotHash,
+    _expected_slot: Slot,
+    _expected_hash: SnapshotHash,
 ) -> Result<()> {
-    let bank_slot = bank.slot();
-    let bank_hash = bank.get_snapshot_hash();
+    let _bank_slot = bank.slot();
+    let _bank_hash = bank.get_snapshot_hash();
 
     /*
     if bank_slot != expected_slot || bank_hash != expected_hash {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -55,7 +55,6 @@ use {
     },
     solana_send_transaction_service::send_transaction_service,
     solana_streamer::socket::SocketAddrSpace,
-    solana_tpu_client::tpu_client::DEFAULT_TPU_ENABLE_UDP,
     solana_validator::{
         admin_rpc_service,
         admin_rpc_service::{load_staked_nodes_overrides, StakedNodesOverrides},


### PR DESCRIPTION
#### Problem
Not sure if I am the only one who sees the errors, but `cargo 1.69.0 (6e9a83356 2023-04-12)` complains the following errors.

```
error: an inner attribute is not permitted in this context
    --> runtime/src/bank.rs:7045:48
     |
7045 |             let should_verify_accounts = false;//!self.rc.accounts.accounts_db.skip_initial_hash_calc;
     |                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: inner attributes, like `#![no_std]`, annotate the item enclosing them, and are usually found at the beginning of source files
     = note: outer attributes, like `#[test]`, annotate the item following them
```

```
error[E0061]: this method takes 12 arguments but 11 arguments were supplied
     --> runtime/src/bank/tests.rs:11326:39
      |
11326 |       let loaded_txs = bank.rc.accounts.load_accounts(
      |  _______________________________________^^^^^^^^^^^^^-
11327 | |         &bank.ancestors,
11328 | |         &[sanitized_tx.clone()],
11329 | |         vec![(Ok(()), None)],
...     |
11337 | |         &LoadedProgramsForTxBatch::default(),
11338 | |     );
      | |_____- an argument of type `bool` is missing
```

```
error[E0308]: mismatched types
   --> runtime/src/cache_hash_data.rs:391:48
    |
391 |                         cache.save(&file_name, &data_this_pass).unwrap();
    |                               ----             ^^^^^^^^^^^^^^^ expected `Vec<Vec<CalculateHashIntermediate>>`, found `&Vec<Vec<CalculateHashIntermediate>>`
    |                               |
    |                               arguments to this method are incorrect
    |
    = note: expected struct `Vec<Vec<accounts_hash::CalculateHashIntermediate>>`
            found reference `&Vec<Vec<accounts_hash::CalculateHashIntermediate>>`
```

#### Summary of Changes
This PR fixes the build errors & warnings in kin_2023_may_11.  For the `load_accounts` API mismatch, this PR passes true for the `set_exempt_rent_epoch_max` argument.